### PR TITLE
fix AWS build action

### DIFF
--- a/.github/workflows/deploy-to-ecs.yml
+++ b/.github/workflows/deploy-to-ecs.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           ECS_TASK_DEFINITION: ${{ secrets.ECS_TASK_DEFINITION }}
         run: |
-          echo "::add-mask::$ECS_TASK_DEFINITION" > task-def.json
+          echo $ECS_TASK_DEFINITION > task-def.json
 
       - name: Update Image ID in ECS Task Definition
         id: task-def


### PR DESCRIPTION
the "::add-mask::" prefix was getting added to the file, which broke the next step